### PR TITLE
Gamestate + click to continue conversation

### DIFF
--- a/Assets/Scenes/GreetingSimulator.unity
+++ b/Assets/Scenes/GreetingSimulator.unity
@@ -274,6 +274,7 @@ RectTransform:
   - {fileID: 523710066}
   - {fileID: 113534615}
   - {fileID: 1807633054}
+  - {fileID: 1752592617}
   m_Father: {fileID: 882560864}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1974,6 +1975,138 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1715455698}
+  m_CullTransparentMesh: 1
+--- !u!1 &1752592616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1752592617}
+  - component: {fileID: 1752592620}
+  - component: {fileID: 1752592619}
+  - component: {fileID: 1752592618}
+  m_Layer: 5
+  m_Name: ClickNextDialogueButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1752592617
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752592616}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 361254278}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1752592618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752592616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1752592619}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 361509147}
+        m_TargetAssemblyTypeName: DialogueManager, Assembly-CSharp
+        m_MethodName: NextDialogueLine
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1752592619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752592616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1752592620
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752592616}
   m_CullTransparentMesh: 1
 --- !u!1 &1782897141 stripped
 GameObject:

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -47,7 +47,7 @@ public class DialogueManager : MonoBehaviour
             Debug.LogError("dialogueText text ui missing");
         }
 
-        SetDialogue();
+        NextDialogueLine();
     }
 
     // Start is called before the first frame update
@@ -60,26 +60,31 @@ public class DialogueManager : MonoBehaviour
 
         input.Dialogue.Continue.performed += pressed =>
         {
-            if (convoIndex < dialogueLines.Count)
-            {
-                SetDialogue();
-            } else if (convoIndex == dialogueLines.Count)
-            {
-                // SARAH: tbh instead should disable this whole convo script
-                dialogueUI.SetActive(false);
-            }
+            NextDialogueLine();
         };
-
     }
 
-    void SetDialogue()
+    public void NextDialogueLine()
     {
-        var dialogue = dialogueLines[convoIndex];
+        if (convoIndex < dialogueLines.Count)
+        {
+            var dialogue = dialogueLines[convoIndex];
+            SetDialogue(dialogue);
+            convoIndex++;
+        }
+        else
+        {
+            // SARAH: tbh instead should disable this whole convo script
+            dialogueUI.SetActive(false);
+        }
+
+        
+    }
+    
+    void SetDialogue(DialogueLineScriptableObject dialogue)
+    {
         characterName.text = dialogue.characterName;
         dialogueText.text = dialogue.dialogue;
-        
-
-        convoIndex++;
     }
     
     

--- a/Assets/Scripts/Persistence/DataPersistenceManager.cs
+++ b/Assets/Scripts/Persistence/DataPersistenceManager.cs
@@ -35,7 +35,9 @@ public class DataPersistenceManager : MonoBehaviour
         this.dataHandler = new FileDataHandler(Application.persistentDataPath, fileName);
         this.dataPersistenceObjects = FindAllDataPersistenceObjects();
         // LoadGame();
-        Debug.Log("Saved in: " + Application.persistentDataPath.ToString());
+        // Debug.Log("Saved in: " + Application.persistentDataPath.ToString());
+        Debug.Log("Begin from new game state");
+        NewGame();
     }
 
     public void NewGame()
@@ -64,6 +66,7 @@ public class DataPersistenceManager : MonoBehaviour
         
     }
 
+    // Saves game to a file.
     public void SaveGame()
     {
         foreach (IDataPersistence dataPersistenceObj in dataPersistenceObjects)
@@ -72,6 +75,15 @@ public class DataPersistenceManager : MonoBehaviour
         }
         
         dataHandler.Save(gameData);
+    }
+
+    // Does not save game to file.  Used for persisting state between scenes.
+    public void TempSaveGame()
+    {
+        foreach (IDataPersistence dataPersistenceObj in dataPersistenceObjects)
+        {
+            dataPersistenceObj.SaveData(ref gameData);
+        }
     }
 
     // public void OnApplicationQuit()


### PR DESCRIPTION
# Feature

Just did two minor things today

In Dungeon1WithHUD, it loads from a new game state (in preparation for using GameData to pass state between scenes without needing to save to file and for using save/load game buttons)

Also in my conversation scene, added an invisible button -- you click it to progress the conversation (space and e already worked from a previous PR)

Next up I'm thinking of building this transition:
Game opens to start menu (maybe add sound)
New game opens to conversation
then you're plopped in dungeon or shop

